### PR TITLE
Expose packs/rspec/support for easier ecosystem testing

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    packs (0.0.4)
+    packs (0.0.5)
       sorbet-runtime
 
 GEM

--- a/lib/packs.rb
+++ b/lib/packs.rb
@@ -1,6 +1,7 @@
 # typed: strict
 
 require 'yaml'
+require 'pathname'
 require 'sorbet-runtime'
 require 'packs/pack'
 require 'packs/private'

--- a/lib/packs/rspec/fixture_helper.rb
+++ b/lib/packs/rspec/fixture_helper.rb
@@ -1,0 +1,33 @@
+# typed: strict
+# frozen_string_literal: true
+
+module FixtureHelper
+  extend T::Sig
+
+  sig { params(path: String, content: String).returns(String) }
+  def write_file(path, content = '')
+    pathname = Pathname.pwd.join(path)
+    FileUtils.mkdir_p(pathname.dirname)
+    pathname.write(content)
+    path
+  end
+
+  sig do
+    params(
+      pack_name: String,
+      config: T::Hash[T.untyped, T.untyped]
+    ).void
+  end
+  def write_pack(
+    pack_name,
+    config = {}
+  )
+    path = Pathname.pwd.join(pack_name).join('package.yml')
+    write_file(path.to_s, YAML.dump(config))
+  end
+
+  sig { params(path: String).void }
+  def delete_app_file(path)
+    File.delete(path)
+  end
+end

--- a/lib/packs/rspec/support.rb
+++ b/lib/packs/rspec/support.rb
@@ -1,0 +1,20 @@
+require_relative 'fixture_helper'
+
+RSpec.configure do |config|
+  config.include FixtureHelper
+
+  config.before do
+    # We bust_cache always because each test may write its own packs
+    Packs.bust_cache!
+  end
+
+  config.around do |example|
+    prefix = [File.basename($0), Process.pid].join('-') # rubocop:disable Style/SpecialGlobalVars
+    tmpdir = Dir.mktmpdir(prefix)
+    Dir.chdir(tmpdir) do
+      example.run
+    end
+  ensure
+    FileUtils.rm_rf(tmpdir)
+  end
+end

--- a/lib/packs/rspec/support.rb
+++ b/lib/packs/rspec/support.rb
@@ -8,6 +8,7 @@ RSpec.configure do |config|
     Packs.bust_cache!
   end
 
+  # Eventually, we could make this opt-in via metadata so someone can use this support without affecting all their tests.
   config.around do |example|
     prefix = [File.basename($0), Process.pid].join('-') # rubocop:disable Style/SpecialGlobalVars
     tmpdir = Dir.mktmpdir(prefix)

--- a/packs.gemspec
+++ b/packs.gemspec
@@ -1,6 +1,6 @@
 Gem::Specification.new do |spec|
   spec.name          = 'packs'
-  spec.version       = '0.0.4'
+  spec.version       = '0.0.5'
   spec.authors       = ['Gusto Engineers']
   spec.email         = ['dev@gusto.com']
   spec.summary       = 'Packs are the specification for gradual modularization in the `rubyatscale` ecosystem.'

--- a/spec/packs_spec.rb
+++ b/spec/packs_spec.rb
@@ -4,7 +4,7 @@ RSpec.describe Packs do
   describe '.all' do
     context 'in app with a simple package' do
       before do
-        write_file('packs/my_pack/package.yml')
+        write_pack('packs/my_pack')
       end
 
       it { expect(Packs.all.count).to eq 1 }
@@ -12,8 +12,8 @@ RSpec.describe Packs do
 
     context 'in an app with nested packs' do
       before do
-        write_file('packs/my_pack/package.yml')
-        write_file('packs/my_pack/subpack/package.yml')
+        write_pack('packs/my_pack')
+        write_pack('packs/my_pack/subpack')
       end
 
       it { expect(Packs.all.count).to eq 2 }
@@ -21,8 +21,8 @@ RSpec.describe Packs do
 
     context 'in an app with a differently configured root' do
       before do
-        write_file('packs/my_pack/package.yml')
-        write_file('components/my_pack/package.yml')
+        write_pack('packs/my_pack')
+        write_pack('components/my_pack')
         write_file('packs.yml', <<~YML)
           pack_paths:
             - packs/*
@@ -35,8 +35,8 @@ RSpec.describe Packs do
 
     context 'in an app with a differently configured root configured via ruby' do
       before do
-        write_file('packs/my_pack/package.yml')
-        write_file('components/my_pack/package.yml')
+        write_pack('packs/my_pack')
+        write_pack('components/my_pack')
         Packs.configure do |config|
           config.pack_paths = ['packs/*', 'components/*']
         end
@@ -47,9 +47,9 @@ RSpec.describe Packs do
 
     context 'in an app with a differently configured root configured via ruby and YML' do
       before do
-        write_file('packs/my_pack/package.yml')
-        write_file('components/my_pack/package.yml')
-        write_file('packages/my_pack/package.yml')
+        write_pack('packs/my_pack')
+        write_pack('components/my_pack')
+        write_pack('packages/my_pack')
         write_file('packs.yml', <<~YML)
           pack_paths:
             - packs/*
@@ -69,7 +69,7 @@ RSpec.describe Packs do
   describe '.find' do
     context 'in app with a simple package' do
       before do
-        write_file('packs/my_pack/package.yml')
+        write_pack('packs/my_pack')
       end
 
       it { expect(Packs.find('packs/my_pack').name).to eq 'packs/my_pack' }
@@ -77,8 +77,8 @@ RSpec.describe Packs do
 
     context 'in an app with nested packs' do
       before do
-        write_file('packs/my_pack/package.yml')
-        write_file('packs/my_pack/subpack/package.yml')
+        write_pack('packs/my_pack')
+        write_pack('packs/my_pack/subpack')
       end
 
       it { expect(Packs.find('packs/my_pack').name).to eq 'packs/my_pack' }
@@ -87,8 +87,8 @@ RSpec.describe Packs do
 
     context 'in an app with a differently configured root' do
       before do
-        write_file('packs/my_pack/package.yml')
-        write_file('components/my_pack/package.yml')
+        write_pack('packs/my_pack')
+        write_pack('components/my_pack')
         write_file('packs.yml', <<~YML)
           pack_paths:
             - packs/*
@@ -103,8 +103,8 @@ RSpec.describe Packs do
 
   describe '.for_file' do
     before do
-      write_file('packs/package_1/package.yml')
-      write_file('packs/package_1_new/package.yml')
+      write_pack('packs/package_1')
+      write_pack('packs/package_1_new')
     end
 
     context 'given a filepath in pack_1' do
@@ -129,9 +129,9 @@ RSpec.describe Packs do
 
     context 'in an app with nested packs' do
       before do
-        write_file('packs/my_pack/package.yml')
+        write_pack('packs/my_pack')
         write_file('packs/my_pack/file.rb')
-        write_file('packs/my_pack/subpack/package.yml')
+        write_pack('packs/my_pack/subpack')
         write_file('packs/my_pack/subpack/file.rb')
       end
 

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -4,6 +4,8 @@ require 'bundler/setup'
 require 'packs'
 require 'pry'
 
+require 'packs/rspec/support'
+
 RSpec.configure do |config|
   # Enable flags like --only-failures and --next-failure
   config.example_status_persistence_file_path = '.rspec_status'
@@ -14,24 +16,4 @@ RSpec.configure do |config|
   config.expect_with :rspec do |c|
     c.syntax = :expect
   end
-
-  config.before do
-    Packs.bust_cache!
-  end
-
-  config.around do |example|
-    prefix = [File.basename($0), Process.pid].join('-') # rubocop:disable Style/SpecialGlobalVars
-    tmpdir = Dir.mktmpdir(prefix)
-    Dir.chdir(tmpdir) do
-      example.run
-    end
-  ensure
-    FileUtils.rm_rf(tmpdir)
-  end
-end
-
-def write_file(path, content = '')
-  pathname = Pathname.pwd.join(path)
-  FileUtils.mkdir_p(pathname.dirname)
-  pathname.write(content)
 end


### PR DESCRIPTION
This replicates the pattern from `rubocop` for easier testing of `rubocop`: https://github.com/rubocop/rubocop/blob/master/lib/rubocop/rspec/support.rb

This exposes some simple helpers to make it easy to create packs in test without needing to stub.