### PR TITLE
Expose Pack#is_gem?

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    packs (0.0.5)
+    packs (0.0.6)
       sorbet-runtime
 
 GEM

--- a/lib/packs/pack.rb
+++ b/lib/packs/pack.rb
@@ -35,6 +35,11 @@ module Packs
       relative_path.basename.to_s
     end
 
+    sig { returns(T::Boolean) }
+    def is_gem?
+      @is_gem ||= T.let(relative_path.glob('*.gemspec').any?, T.nilable(T::Boolean))
+    end
+
     sig { returns(T::Hash[T.untyped, T.untyped]) }
     def metadata
       raw_hash['metadata'] || {}

--- a/packs.gemspec
+++ b/packs.gemspec
@@ -1,6 +1,6 @@
 Gem::Specification.new do |spec|
   spec.name          = 'packs'
-  spec.version       = '0.0.5'
+  spec.version       = '0.0.6'
   spec.authors       = ['Gusto Engineers']
   spec.email         = ['dev@gusto.com']
   spec.summary       = 'Packs are the specification for gradual modularization in the `rubyatscale` ecosystem.'

--- a/spec/packs/pack_spec.rb
+++ b/spec/packs/pack_spec.rb
@@ -43,4 +43,25 @@ RSpec.describe Packs::Pack do
       end
     end
   end
+
+  describe '.is_gem?' do
+    let(:subject) { Packs.find('packs/my_pack').is_gem? }
+
+    context 'pack is not a gem' do
+      before do
+        write_file('packs/my_pack/package.yml')
+      end
+
+      it { is_expected.to eq false }
+    end
+
+    context 'pack is a gem' do
+      before do
+        write_file('packs/my_pack/package.yml')
+        write_file('packs/my_pack/my_pack.gemspec')
+      end
+
+      it { is_expected.to eq true }
+    end
+  end
 end


### PR DESCRIPTION
There are many instances in `stimpack` (which may become `packs-rails`) where we do not want to take certain actions if a `Pack` is a gem.

This exposes a method, `is_gem?`, permitting queries like `Packs.all.reject(&:is_gem?)`, which may be useful when deciding not to, for example, load factories or load paths from gems.

This will also be more helpful as the line between a pack and a gem is more clearly defined and paths to migrate from pack to gem and gem to pack are paved.
