### PR TITLE
Support multiple depths for pack definition

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    packs (0.0.6)
+    packs (0.0.7)
       sorbet-runtime
 
 GEM

--- a/lib/packs/private/configuration.rb
+++ b/lib/packs/private/configuration.rb
@@ -7,8 +7,7 @@ module Packs
       CONFIGURATION_PATHNAME = T.let(Pathname.new('packs.yml'), Pathname)
 
       DEFAULT_PACK_PATHS = T.let([
-                                   'packs/*',
-                                   'packs/*/*'
+                                   'packs/**/*',
                                  ], T::Array[String])
 
       prop :pack_paths, T::Array[String]

--- a/spec/packs_spec.rb
+++ b/spec/packs_spec.rb
@@ -99,6 +99,16 @@ RSpec.describe Packs do
       it { expect(Packs.find('packs/my_pack').name).to eq 'packs/my_pack' }
       it { expect(Packs.find('components/my_pack').name).to eq 'components/my_pack' }
     end
+
+    context 'in an app with packs with different depth' do
+      before do
+        write_pack('packs/my_pack')
+        write_pack('packs/subject/other_pack')
+        write_pack('packs/other_subject/small_subject/deep_pack')
+      end
+
+      it { expect(Packs.all.count).to eq 3 }
+    end
   end
 
   describe '.for_file' do


### PR DESCRIPTION
Hello :wave: 

I realized that `Packs` can't be defined in multiple depth levels, it only supports two levels which seems limiting.

I was actually working on a project were I needed more depth than just two levels and everything broke :(
So I thought adding this, which was very easy, but I am not sure if this is a desired functionality.

I took the liberty of adding a small test too.

Cheers and happy modularization 