### PR TITLE
Relocate directory-sorting behavior to Packs.for_file

### DIFF
--- a/lib/packs.rb
+++ b/lib/packs.rb
@@ -27,7 +27,8 @@ module Packs
       path_string = file_path.to_s
       @for_file = T.let(@for_file, T.nilable(T::Hash[String, T.nilable(Pack)]))
       @for_file ||= {}
-      @for_file[path_string] ||= all.find { |package| path_string.start_with?("#{package.name}/") || path_string == package.name }
+      @for_file[path_string] ||= all.sort_by { |package| -package.name.length }
+        .find { |package| path_string.start_with?("#{package.name}/") || path_string == package.name }
     end
 
     sig { void }
@@ -63,9 +64,7 @@ module Packs
           Pack.from(path)
         end
 
-        # We want to match more specific paths first so for_file works correctly.
-        sorted_packages = all_packs.sort_by { |package| -package.name.length }
-        sorted_packages.to_h { |p| [p.name, p] }
+        all_packs.to_h { |p| [p.name, p] }
       end
     end
 

--- a/spec/packs_spec.rb
+++ b/spec/packs_spec.rb
@@ -10,6 +10,18 @@ RSpec.describe Packs do
       it { expect(Packs.all.count).to eq 1 }
     end
 
+    context 'given two package names with a common root' do
+      before do
+        write_pack('packs/my_pack')
+        write_pack('packs/z_pack_with_very_long_name')
+        write_pack('packs/first_pack')
+      end
+
+      it 'preserves lexical order' do
+        expect(Packs.all.map(&:name)).to eq %w[packs/first_pack packs/my_pack packs/z_pack_with_very_long_name]
+      end
+    end
+
     context 'in an app with nested packs' do
       before do
         write_pack('packs/my_pack')


### PR DESCRIPTION
The RSpec integration in the `packs-rails` gem depends on `Packs.all` to
return a collection of directory names representing packages.

https://github.com/rubyatscale/packs-rails/blob/505fceb9ff50f666ee8c9c0ffabf1037c2519c43/lib/packs/rails/integrations/rspec.rb#L18

The current implementation of `Packs.all` returns a collection of
package names sorted by the length of their directory entries, a
behavior that `Packs.for_file` relies on. However, this
out-of-lexical-order collection creates problems for RSpec in that fails
to run any spec files found in directories not listed in the expected
alphabetical order. [This Github issue goes into
moredetail.](https://github.com/rubyatscale/packs-rails/issues/58)

The solution to this problem looks to be straightforward: relocate the
block that sorts package names by their length to the implementation of
`Packs.for_file`, leaving `Packs.all` to return package names in the
same order they were read off the filesystem.
