### PR TITLE
use universal-darwin for bundle platform

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -54,22 +54,13 @@ GEM
     rubocop-ast (1.24.0)
       parser (>= 3.1.1.0)
     ruby-progressbar (1.11.0)
-    sorbet (0.5.10479)
-      sorbet-static (= 0.5.10479)
-    sorbet-runtime (0.5.10479)
-    sorbet-static (0.5.10479-universal-darwin-14)
-    sorbet-static (0.5.10479-universal-darwin-15)
-    sorbet-static (0.5.10479-universal-darwin-16)
-    sorbet-static (0.5.10479-universal-darwin-17)
-    sorbet-static (0.5.10479-universal-darwin-18)
-    sorbet-static (0.5.10479-universal-darwin-19)
-    sorbet-static (0.5.10479-universal-darwin-20)
-    sorbet-static (0.5.10479-universal-darwin-21)
-    sorbet-static (0.5.10479-universal-darwin-22)
-    sorbet-static (0.5.10479-x86_64-linux)
-    sorbet-static-and-runtime (0.5.10479)
-      sorbet (= 0.5.10479)
-      sorbet-runtime (= 0.5.10479)
+    sorbet (0.5.11370)
+      sorbet-static (= 0.5.11370)
+    sorbet-runtime (0.5.11370)
+    sorbet-static (0.5.11370-universal-darwin)
+    sorbet-static-and-runtime (0.5.11370)
+      sorbet (= 0.5.11370)
+      sorbet-runtime (= 0.5.11370)
     spoom (1.1.12)
       sorbet (>= 0.5.9204)
       sorbet-runtime (>= 0.5.9204)
@@ -97,7 +88,7 @@ GEM
       yard (>= 0.9)
 
 PLATFORMS
-  ruby
+  universal-darwin
 
 DEPENDENCIES
   bundler (~> 2.2.16)
@@ -109,4 +100,4 @@ DEPENDENCIES
   tapioca
 
 BUNDLED WITH
-   2.2.33
+   2.2.34

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -58,6 +58,7 @@ GEM
       sorbet-static (= 0.5.11370)
     sorbet-runtime (0.5.11370)
     sorbet-static (0.5.11370-universal-darwin)
+    sorbet-static (0.5.11370-x86_64-linux)
     sorbet-static-and-runtime (0.5.11370)
       sorbet (= 0.5.11370)
       sorbet-runtime (= 0.5.11370)
@@ -89,6 +90,7 @@ GEM
 
 PLATFORMS
   universal-darwin
+  x86_64-linux
 
 DEPENDENCIES
   bundler (~> 2.2.16)


### PR DESCRIPTION
Adds the universal-darwin platform to hopefully stop the persistent sorbet-static bundler issues we run into

Update bundler version: `bundle update --bundler`
Added `universal-darwin` to Platforms
Run `bundle update sorbet-static`
Add x86_64-linux platform `bundle lock --add-platform x86_64-linux`