### PR TITLE
Add README template pathname

### DIFF
--- a/lib/packs/specification/configuration.rb
+++ b/lib/packs/specification/configuration.rb
@@ -10,15 +10,18 @@ module Packs
                                    'packs/*',
                                    'packs/*/*'
                                  ], T::Array[String])
+      DEFAULT_README_TEMPLATE_PATHNAME = T.let(Pathname.new('README_TEMPLATE.md'), Pathname)
 
       prop :pack_paths, T::Array[String]
+      prop :readme_template_pathname, Pathname
 
       sig { returns(Configuration) }
       def self.fetch
         config_hash = CONFIGURATION_PATHNAME.exist? ? YAML.load_file(CONFIGURATION_PATHNAME) : {}
 
         new(
-          pack_paths: pack_paths(config_hash)
+          pack_paths: pack_paths(config_hash),
+          readme_template_pathname: readme_template_pathname(config_hash)
         )
       end
 
@@ -29,6 +32,16 @@ module Packs
           DEFAULT_PACK_PATHS.dup
         else
           Array(specified_pack_paths)
+        end
+      end
+
+      sig { params(config_hash: T::Hash[T.untyped, T.untyped]).returns(Pathname) }
+      def self.readme_template_pathname(config_hash)
+        specified_readme_template_path = config_hash['readme_template_path']
+        if specified_readme_template_path.nil?
+          DEFAULT_README_TEMPLATE_PATHNAME
+        else
+          Pathname.new(specified_readme_template_path)
         end
       end
     end


### PR DESCRIPTION
We want to allow users to specify a README template other than the default template currently defined in `packs`. The README_TODO file currently contains the following text:

```
Welcome to `#{pack_name}`!

If you're the author, please consider replacing this file with a README.md, which may contain:
  - What your pack is and does
  - How you expect people to use your pack
  - Example usage of your pack's public API (which lives in `#{pack_name}/#{ParsePackwerk::DEFAULT_PUBLIC_PATH}`)
  - Limitations, risks, and important considerations of usage
  - How to get in touch with eng and other stakeholders for questions or issues pertaining to this pack (note: it is recommended to add ownership in `#{pack_name}/package.yml` under the `owner` metadata key)
  - What SLAs/SLOs (service level agreements/objectives), if any, your package provides
  - When in doubt, keep it simple
  - Anything else you may want to include!

 README.md files are under version control and should change as your public API changes.#{' '}

See #{documentation_link} for more info!
```

Some organizations may want to use their own README template. [This issue](https://github.com/rubyatscale/packs/issues/154) requested the ability to customize the README but was closed due to inactivity. With this change, users can define their own README template, `README_TEMPLATE.md`, in the project root or specify an alternative path in `packs.yml`.

Corresponding packs change: https://github.com/rubyatscale/packs/pull/165

- [ ] TODO: tests
- [ ] Bump version