### PR TITLE
Add Dependabot config for monthly Bundler updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,10 @@
+version: 2
+updates:
+  - package-ecosystem: "bundler"
+    directory: "/"
+    schedule:
+      interval: "monthly"
+    groups:
+      bundler:
+        patterns:
+          - "*"


### PR DESCRIPTION
## Summary

Adds a Dependabot configuration to keep Bundler dependencies up to date automatically.

- Updates all Bundler dependencies on a **monthly** schedule
- Groups all updates into a single `bundler` group, so each run produces one consolidated PR
- Uses the latest Dependabot config schema (`version: 2`)

## Motivation

This automates dependency maintenance to eliminate the need for manual dependency/security PRs like [rubyatscale/pack_stats#56](https://github.com/rubyatscale/pack_stats/pull/56), where critical security advisories had to be triaged and bumped by hand. With Dependabot in place, these updates are surfaced automatically each month.
